### PR TITLE
Update AbstractAsyncPdfPrint.java

### DIFF
--- a/src/main/java/org/sirio6/services/print/AbstractAsyncPdfPrint.java
+++ b/src/main/java/org/sirio6/services/print/AbstractAsyncPdfPrint.java
@@ -93,6 +93,10 @@ abstract public class AbstractAsyncPdfPrint extends AbstractPdfPrint
 
     AsyncPdfJob job = createJob();
     AbstractReportParametersInfo ri = getParameters(idUser, codiceStampa, context);
+    context.put(PrintContext.PBEAN_KEY, ri);
+    context.put(PrintContext.REPORT_INFO_KEY, ri.getInfo());
+    context.put(PrintContext.REPORT_NAME_KEY, ri.getNome());
+    context.put(PrintContext.SESSION_KEY, sessione);
 
     job.init(this, idUser, ri.getPlugin(), context);
     job.start();


### PR DESCRIPTION
Passaggio parametri stampa asincrona.
Bug riscontrato su stampa refertoSingolo (per mancato passaggio nome report stampava sempre il referto completo)